### PR TITLE
fix(telegram-bot): watchdog + xray keepalive against silent getUpdates freeze

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ infra-docker/
 | `postgres`  | `postgres:17`                          | `5432:5432`              | БД; named volume `postgresql_data` |
 | `kafka`     | `apache/kafka:4.1.0`                   | —                        | KRaft-режим (без Zookeeper); порты 9092/9093 внутри сети |
 | `kafka-ui`  | `tchiotludo/akhq:latest`               | —                        | Веб-интерфейс Kafka (AKHQ); базовая аутентификация |
-| `telegram-bot`       | build из `./services/telegram-bot/`          | —                        | Telegram-бот (опросник для подбора туров); polling-режим; watchdog на `job_queue` перезапускает процесс при зависании getUpdates (см. `XRAY-CLIENT.md`) |
+| `telegram-bot`       | build из `./services/telegram-bot/`          | —                        | Telegram-бот (опросник для подбора туров); polling-режим; watchdog на `job_queue` перезапускает процесс при зависании запросов |
 | `xray`      | `ghcr.io/xtls/xray-core:latest`        | —                        | VLESS+Reality прокси-клиент; HTTP `:3128`, SOCKS5 `:1080` внутри сети; используется telegram-bot |
 
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ infra-docker/
 | `postgres`  | `postgres:17`                          | `5432:5432`              | БД; named volume `postgresql_data` |
 | `kafka`     | `apache/kafka:4.1.0`                   | —                        | KRaft-режим (без Zookeeper); порты 9092/9093 внутри сети |
 | `kafka-ui`  | `tchiotludo/akhq:latest`               | —                        | Веб-интерфейс Kafka (AKHQ); базовая аутентификация |
-| `telegram-bot`       | build из `./services/telegram-bot/`          | —                        | Telegram-бот (опросник для подбора туров); polling-режим |
+| `telegram-bot`       | build из `./services/telegram-bot/`          | —                        | Telegram-бот (опросник для подбора туров); polling-режим; watchdog на `job_queue` перезапускает процесс при зависании getUpdates (см. `XRAY-CLIENT.md`) |
 | `xray`      | `ghcr.io/xtls/xray-core:latest`        | —                        | VLESS+Reality прокси-клиент; HTTP `:3128`, SOCKS5 `:1080` внутри сети; используется telegram-bot |
 
 ---

--- a/XRAY-CLIENT.md
+++ b/XRAY-CLIENT.md
@@ -138,6 +138,18 @@ XRAY_HTTP_PROXY=
 docker compose up -d telegram-bot
 ```
 
+**Бот перестаёт отвечать через 15-20 минут работы (getUpdates замолкает без ошибок)**
+
+Reality-туннель до сервера иногда обрывается "тихо" (без FIN/RST) — типично для DPI/NAT на пути через РФ/КЗ сети. Без активного TCP keepalive ни xray, ни клиент не замечают обрыв, и переподключение может зависнуть дольше собственных таймаутов `httpx`.
+
+`services/xray/config.json.example` уже содержит `streamSettings.sockopt.tcpKeepAliveInterval: 15` на outbound `vless` — перенеси это же поле в свой `services/xray/config.json` на сервере (он не коммитится и не обновляется автоматически) и перезапусти `xray`:
+
+```bash
+docker compose up -d xray
+```
+
+Дополнительно `telegram-bot` теперь сам следит за живостью поллинга (watchdog на `job_queue`, см. `services/telegram-bot/telegram_bot.py`) и принудительно завершает процесс после нескольких неудачных проверок подряд, чтобы `restart: unless-stopped` его поднял заново.
+
 ---
 
 ## Альтернативная настройка прокси через код

--- a/XRAY-CLIENT.md
+++ b/XRAY-CLIENT.md
@@ -28,6 +28,12 @@ cp services/xray/config.json.example services/xray/config.json
 
 Эти данные выдаёт сервер при создании пользователя (например через `3x-ui` панель или CLI `xray`).
 
+Кроме серверных данных, в `streamSettings` outbound-а `vless` есть параметр, который не нужно менять, но полезно понимать:
+
+| Поле | Назначение |
+|------|-----------|
+| `sockopt.tcpKeepAliveInterval` | Интервал (в секундах) TCP keepalive-проб на туннеле до Reality-сервера. Без него "тихий" обрыв соединения (без FIN/RST — типично для DPI/NAT на пути через РФ/КЗ сети) не детектируется активно, и переподключение может зависнуть дольше собственных таймаутов клиента. |
+
 ```plain
 Если сервер настроен через панель 3x-ui (судя по XRAY-CLIENT.md, у вас так)
 
@@ -137,18 +143,6 @@ XRAY_HTTP_PROXY=
 ```bash
 docker compose up -d telegram-bot
 ```
-
-**Бот перестаёт отвечать через 15-20 минут работы (getUpdates замолкает без ошибок)**
-
-Reality-туннель до сервера иногда обрывается "тихо" (без FIN/RST) — типично для DPI/NAT на пути через РФ/КЗ сети. Без активного TCP keepalive ни xray, ни клиент не замечают обрыв, и переподключение может зависнуть дольше собственных таймаутов `httpx`.
-
-`services/xray/config.json.example` уже содержит `streamSettings.sockopt.tcpKeepAliveInterval: 15` на outbound `vless` — перенеси это же поле в свой `services/xray/config.json` на сервере (он не коммитится и не обновляется автоматически) и перезапусти `xray`:
-
-```bash
-docker compose up -d xray
-```
-
-Дополнительно `telegram-bot` теперь сам следит за живостью поллинга (watchdog на `job_queue`, см. `services/telegram-bot/telegram_bot.py`) и принудительно завершает процесс после нескольких неудачных проверок подряд, чтобы `restart: unless-stopped` его поднял заново.
 
 ---
 

--- a/docs/issues/16.md
+++ b/docs/issues/16.md
@@ -39,7 +39,7 @@ GitHub Issue: https://github.com/tourismania/infra-docker/issues/16
 - `services/telegram-bot/telegram_bot.py` — watchdog-джоба `watchdog_check` на `job_queue.run_repeating`, явные таймауты в `ApplicationBuilder`.
 - `services/telegram-bot/requirements.txt` — добавлен extra `python-telegram-bot[job-queue]` (нужен APScheduler для `job_queue`).
 - `services/xray/config.json.example` — добавлен `sockopt.tcpKeepAliveInterval: 15` на outbound `vless`.
-- `XRAY-CLIENT.md` — секция отладки про зависание бота и необходимость перенести keepalive в боевой `config.json` вручную (он не коммитится).
+- `XRAY-CLIENT.md` — описание параметра `sockopt.tcpKeepAliveInterval` рядом с остальными полями конфига; необходимость перенести keepalive в боевой `config.json` вручную (он не коммитится) отмечена в PR test plan.
 - `CLAUDE.md` — обновлена заметка про сервис `telegram-bot`.
 
 **Важно:** боевой `services/xray/config.json` не коммитится и не обновится автоматически — после мёржа нужно вручную добавить `sockopt.tcpKeepAliveInterval` в конфиг на сервере и перезапустить `xray`.

--- a/docs/issues/16.md
+++ b/docs/issues/16.md
@@ -1,0 +1,45 @@
+# Issue #16 — Telegram-бот перестаёт слать getUpdates после ~15-17 минут работы (зависает без ошибок)
+
+GitHub Issue: https://github.com/tourismania/infra-docker/issues/16
+
+## Проблема
+
+На продакшене `telegram-bot` (services/telegram-bot) стабильно перестаёт отправлять long-polling запросы `getUpdates` к Telegram API примерно через 15–17 минут работы.
+
+Из логов: ровный ритм запросов каждые ~10.2 сек с ответами `200 OK`, затем — полная тишина: ни одной новой строки лога, ни `WARNING`, ни `ERROR`. `docker compose ps` показывает контейнер `Up` (процесс не падает и не перезапускается), но бот не отвечает пользователям.
+
+## Гипотеза причины
+
+Бот ходит к `api.telegram.org` через `xray` (VLESS+Reality-туннель, HTTP-прокси `xray:3128`, см. `XRAY-CLIENT.md`). Вероятный сценарий:
+
+1. Reality-туннель `xray → сервер` обрывается "тихо" (без FIN/RST) — типично для DPI/NAT на пути в РФ/КЗ сетях.
+2. `httpx`-клиент внутри `python-telegram-bot` при попытке переоткрыть соединение к `xray:3128` виснет на блокирующем вызове (вероятно DNS-резолвинг хоста `xray` через встроенный Docker DNS), который не покрывается async-таймаутами `httpx`/PTB, т.к. уходит в непрерываемый OS-тред.
+3. У PTB для `get_updates` отдельный HTTP-клиент с `connection_pool_size=1` — зависание единственного соединения навсегда останавливает поллинг без единой ошибки в логах.
+
+В `services/xray/config.json(.example)` у outbound `vless` не настроен TCP keepalive (`streamSettings.sockopt.tcpKeepAliveInterval`), поэтому мёртвый туннель не детектируется активно ни на стороне xray, ни на стороне бота.
+
+## Acceptance Criteria
+
+- [x] В `services/xray/config.json.example` добавлен `sockopt.tcpKeepAliveInterval` на outbound `vless`, чтобы обрыв туннеля обнаруживался за секунды.
+- [x] В `telegram_bot.py` добавлен watchdog: периодическая проверка живости поллинга (`job_queue`, вызов `bot.get_me()` с explicit bounded timeout); при нескольких неудачах подряд — принудительное завершение процесса (`os._exit`), чтобы `restart: unless-stopped` реально перезапускал зависший контейнер.
+- [x] Явно заданы таймауты для `get_updates` и обычных bot-запросов через `ApplicationBuilder` (`get_updates_read_timeout`, `get_updates_connect_timeout`, `read_timeout`, `connect_timeout`, `pool_timeout`) вместо дефолтов.
+- [x] Добавлено логирование, которое явно показывает состояние watchdog-проверок (успех/неудача каждого цикла) и ERROR с трейсбеком перед принудительным рестартом.
+- [x] Обновлена документация (`CLAUDE.md`, `XRAY-CLIENT.md`), добавлен `docs/issues/16.md`.
+
+## Negative Constraints
+
+- Не трогать бизнес-логику опросника (состояния `ConversationHandler`, тексты, порядок вопросов) — только сетевой/инфраструктурный слой.
+- Не убирать поддержку работы без прокси (`XRAY_HTTP_PROXY=` пустой должен продолжать работать).
+- Не добавлять новые внешние зависимости без необходимости (`requirements.txt` сейчас — только `python-telegram-bot==21.9`).
+- Не менять протокол/учётные данные Reality в `config.json.example` — только `sockopt`.
+- Watchdog не должен рестартовать контейнер на единичном сетевом блипе — нужен порог из нескольких неудачных попыток подряд, не одна.
+
+## Реализация
+
+- `services/telegram-bot/telegram_bot.py` — watchdog-джоба `watchdog_check` на `job_queue.run_repeating`, явные таймауты в `ApplicationBuilder`.
+- `services/telegram-bot/requirements.txt` — добавлен extra `python-telegram-bot[job-queue]` (нужен APScheduler для `job_queue`).
+- `services/xray/config.json.example` — добавлен `sockopt.tcpKeepAliveInterval: 15` на outbound `vless`.
+- `XRAY-CLIENT.md` — секция отладки про зависание бота и необходимость перенести keepalive в боевой `config.json` вручную (он не коммитится).
+- `CLAUDE.md` — обновлена заметка про сервис `telegram-bot`.
+
+**Важно:** боевой `services/xray/config.json` не коммитится и не обновится автоматически — после мёржа нужно вручную добавить `sockopt.tcpKeepAliveInterval` в конфиг на сервере и перезапустить `xray`.

--- a/services/telegram-bot/requirements.txt
+++ b/services/telegram-bot/requirements.txt
@@ -1,1 +1,1 @@
-python-telegram-bot==21.9
+python-telegram-bot[job-queue]==21.9

--- a/services/telegram-bot/telegram_bot.py
+++ b/services/telegram-bot/telegram_bot.py
@@ -1043,7 +1043,6 @@ async def error_handler(update: object, context: ContextTypes.DEFAULT_TYPE):
 
 
 async def watchdog_check(context: ContextTypes.DEFAULT_TYPE):
-    """Проверяет, что Telegram API реально отвечает, и перезапускает процесс при зависании."""
     failures = context.application.bot_data.get("watchdog_failures", 0)
     try:
         await asyncio.wait_for(context.bot.get_me(), timeout=WATCHDOG_TIMEOUT_SECONDS)

--- a/services/telegram-bot/telegram_bot.py
+++ b/services/telegram-bot/telegram_bot.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import os
 import sys
@@ -12,9 +13,19 @@ logging.basicConfig(
     level=logging.INFO
 )
 logger = logging.getLogger(__name__)
+watchdog_logger = logging.getLogger("watchdog")
 
 BOT_TOKEN = os.getenv("TELEGRAM_BOT_TOKEN")
 ADMIN_CHAT_ID = os.getenv("TELEGRAM_BOT_ADMIN_CHAT_ID")
+
+# Бот может годами висеть на getUpdates через xray/Reality-туннель, который
+# иногда "тихо" обрывается (без FIN/RST) — httpx в этом случае может зависнуть
+# на переподключении дольше своих же таймаутов (см. issue #16). Watchdog
+# периодически дёргает get_me() и после нескольких неудач подряд убивает
+# процесс, чтобы `restart: unless-stopped` реально перезапустил контейнер.
+WATCHDOG_INTERVAL_SECONDS = int(os.getenv("WATCHDOG_INTERVAL_SECONDS", "180"))
+WATCHDOG_TIMEOUT_SECONDS = int(os.getenv("WATCHDOG_TIMEOUT_SECONDS", "20"))
+WATCHDOG_MAX_FAILURES = int(os.getenv("WATCHDOG_MAX_FAILURES", "3"))
 
 if not BOT_TOKEN:
     logger.critical("BOT_TOKEN is not set")
@@ -1031,8 +1042,45 @@ async def error_handler(update: object, context: ContextTypes.DEFAULT_TYPE):
     logger.error(f"Ошибка: {context.error}", exc_info=context.error)
 
 
+async def watchdog_check(context: ContextTypes.DEFAULT_TYPE):
+    """Проверяет, что Telegram API реально отвечает, и перезапускает процесс при зависании."""
+    failures = context.application.bot_data.get("watchdog_failures", 0)
+    try:
+        await asyncio.wait_for(context.bot.get_me(), timeout=WATCHDOG_TIMEOUT_SECONDS)
+    except Exception as e:
+        failures += 1
+        context.application.bot_data["watchdog_failures"] = failures
+        watchdog_logger.error(
+            "Проверка связи с Telegram API провалена (%s/%s): %s",
+            failures, WATCHDOG_MAX_FAILURES, e, exc_info=e,
+        )
+        if failures >= WATCHDOG_MAX_FAILURES:
+            watchdog_logger.critical(
+                "Поллинг не отвечает %s проверок подряд — принудительный выход для перезапуска контейнера",
+                failures,
+            )
+            os._exit(1)
+        return
+
+    if failures:
+        watchdog_logger.info("Связь с Telegram API восстановлена после %s неудачных проверок", failures)
+    context.application.bot_data["watchdog_failures"] = 0
+    watchdog_logger.info("Watchdog: связь с Telegram API в порядке")
+
+
 def main():
-    app = ApplicationBuilder().token(BOT_TOKEN).build()
+    app = (
+        ApplicationBuilder()
+        .token(BOT_TOKEN)
+        .connect_timeout(10)
+        .read_timeout(10)
+        .write_timeout(20)
+        .pool_timeout(10)
+        .get_updates_connect_timeout(10)
+        .get_updates_read_timeout(30)
+        .get_updates_pool_timeout(10)
+        .build()
+    )
 
     conv = ConversationHandler(
         entry_points=[CommandHandler("start", start)],
@@ -1076,6 +1124,23 @@ def main():
 
     app.add_handler(conv)
     app.add_error_handler(error_handler)
+
+    if app.job_queue is not None:
+        app.job_queue.run_repeating(
+            watchdog_check,
+            interval=WATCHDOG_INTERVAL_SECONDS,
+            first=WATCHDOG_INTERVAL_SECONDS,
+            name="watchdog",
+        )
+        logger.info(
+            "Watchdog включен: проверка каждые %sс, таймаут %sс, порог рестарта — %s неудач подряд",
+            WATCHDOG_INTERVAL_SECONDS, WATCHDOG_TIMEOUT_SECONDS, WATCHDOG_MAX_FAILURES,
+        )
+    else:
+        logger.warning(
+            "JobQueue недоступен (нет extra 'job-queue' у python-telegram-bot) — watchdog отключен"
+        )
+
     logger.info("Бот запущен ✅")
     app.run_polling(allowed_updates=Update.ALL_TYPES)
 

--- a/services/xray/config.json.example
+++ b/services/xray/config.json.example
@@ -45,6 +45,9 @@
       "streamSettings": {
         "network": "tcp",
         "security": "reality",
+        "sockopt": {
+          "tcpKeepAliveInterval": 15
+        },
         "realitySettings": {
           "fingerprint": "chrome",
           "serverName": "www.microsoft.com",


### PR DESCRIPTION
## Summary
- Бот молча зависал на `getUpdates` через ~15-17 минут работы (xray/Reality-туннель обрывается "тихо", без FIN/RST) — процесс жил, но не отвечал.
- Добавлен watchdog на `job_queue`: периодически дёргает `get_me()` с bounded timeout, после N неудач подряд — `os._exit(1)`, чтобы `restart: unless-stopped` реально перезапустил контейнер.
- Явные таймауты для `get_updates` и обычных запросов через `ApplicationBuilder`.
- TCP keepalive (`sockopt.tcpKeepAliveInterval`) на outbound `vless` в `services/xray/config.json.example`.
- Обновлены `XRAY-CLIENT.md`, `CLAUDE.md`, добавлен `docs/issues/16.md`.

Closes #16

## Test plan
- [x] `python3 -m py_compile services/telegram-bot/telegram_bot.py`
- [x] Установлен `requirements.txt` в чистый venv, проверено что `ApplicationBuilder` поддерживает все вызываемые методы таймаутов и что `job_queue` доступен (extra `[job-queue]` подтянул APScheduler)
- [x] `services/xray/config.json.example` валиден как JSON
- [ ] Прогнать бота в проде через xray-прокси и убедиться, что через 15+ минут поллинг не замолкает (или, если всё же замолкнет, что watchdog перезапускает контейнер и это видно в логах `watchdog`)
- [ ] На сервере вручную добавить `sockopt.tcpKeepAliveInterval` в боевой `services/xray/config.json` (не коммитится) и перезапустить `xray`

🤖 Generated with [Claude Code](https://claude.com/claude-code)