### PR TITLE
docs(issues): export issue #19 description

### DIFF
--- a/docs/issues/19.md
+++ b/docs/issues/19.md
@@ -1,0 +1,49 @@
+# Issue #19 — Подавить ложное PTBUserWarning про per_message/CallbackQueryHandler в telegram-bot
+
+GitHub Issue: https://github.com/tourismania/infra-docker/issues/19
+
+## Проблема
+
+В логах `telegram-bot` при старте (`docker compose logs`) выводится предупреждение:
+
+```
+/app/telegram_bot.py:1084: PTBUserWarning: If 'per_message=False', 'CallbackQueryHandler' will not be tracked for every message.
+Read this FAQ entry to learn more about the per_* settings:
+https://github.com/python-telegram-bot/python-telegram-bot/wiki/Frequently-Asked-Questions#what-do-the-per_-settings-in-conversationhandler-do
+```
+
+Источник — `ConversationHandler` в `services/telegram-bot/telegram_bot.py:1084`. `python-telegram-bot` предупреждает о том, что при `per_message=False` (значение по умолчанию, сейчас не задано явно) `CallbackQueryHandler` отслеживается не по каждому сообщению, а по паре `(chat_id, user_id)`.
+
+## Анализ
+
+`states` конверсации смешивают два типа обработчиков:
+- состояния только с `CallbackQueryHandler` (`WELCOME`, `WHO_TRAVELS`, `FLIGHT_DURATION`, `TRANSFER`, `TRIP_GOAL`, `ATMOSPHERE`, `HOTEL_STYLE`, `ACTIVITIES`, `DESIGN_STYLE`, `ACCOMMODATION_TYPE`, `SLEEP_SENSITIVITY`, `MEAL_PLAN`, `ALACARTE`, `CUISINE`, `OUTSIDE_WALK`, `BEACH_TYPE`, `BEACH_FEATURES`, `CONTACT_METHOD`, `DISCUSS_FORMAT`);
+- состояния только с `MessageHandler` (`PARTICIPANTS`, `DATES`, `DEPARTURE_CITY`, `BUDGET`, `AIRLINE_PREF`, `LAYOVER`, `LUGGAGE`, `SLEEP_SCHEDULE`, `DIETARY`, `SPECIAL_WISHES`, `TOP_PRIORITIES`, `FIO`, `CONTACT_LINK`).
+
+Согласно `ConversationHandler.check_update` (python-telegram-bot), при `per_message=True` любое обновление без `callback_query` отбрасывается (`if self.per_message and not update.callback_query: return None`). Поставить `per_message=True` для всей конверсации нельзя — это сломает все состояния с `MessageHandler` (бот перестанет реагировать на текстовые ответы пользователя).
+
+Опросник — линейный сценарий один-пользователь-один-диалог: пользователь не открывает несколько инлайн-меню параллельно в разных сообщениях одновременно, поэтому отслеживание `CallbackQueryHandler` по сообщению (`per_message=True`) не требуется по дизайну — текущее поведение (`per_message=False`, трекинг по `chat_id`+`user_id`) корректно. Предупреждение в этом случае — ложное срабатывание, а не признак бага, но сейчас оно засоряет логи при каждом старте контейнера.
+
+Согласно FAQ python-telegram-bot, рекомендованный способ для этого случая — явно подавить именно это предупреждение:
+
+```python
+from warnings import filterwarnings
+from telegram.warnings import PTBUserWarning
+
+filterwarnings(action="ignore", message=r".*CallbackQueryHandler", category=PTBUserWarning)
+```
+
+## Acceptance Criteria
+
+- [ ] В `services/telegram-bot/telegram_bot.py` добавлено явное подавление именно предупреждения `PTBUserWarning` про `per_message`/`CallbackQueryHandler` (через `warnings.filterwarnings` с точным `message`-паттерном, не глобальное отключение всех `PTBUserWarning`).
+- [ ] Рядом с подавлением — короткий комментарий/докстрока, объясняющая, почему `per_message=False` осознанный выбор для этой конверсации (смешанные `CallbackQueryHandler`/`MessageHandler`-состояния), чтобы предупреждение не включили обратно по ошибке в будущем.
+- [ ] После сборки и рестарта контейнера `telegram-bot` в `docker compose logs` предупреждение `PTBUserWarning: If 'per_message=False'...` больше не появляется.
+- [ ] Опросник по-прежнему работает end-to-end: инлайн-кнопки (`CallbackQueryHandler`-состояния) и текстовый ввод (`MessageHandler`-состояния) обрабатываются как раньше.
+- [ ] Добавлен `docs/issues/19.md` с описанием задачи (см. `CLAUDE.md`, раздел Development Process).
+
+## Negative Constraints
+
+- Не менять `per_message` на `True` для всей конверсации — сломает состояния с `MessageHandler`.
+- Не подавлять все `PTBUserWarning` целиком — фильтр должен быть точечным (по тексту сообщения про `CallbackQueryHandler`/`per_message`), чтобы не скрыть другие полезные предупреждения PTB.
+- Не менять бизнес-логику опросника (порядок состояний, тексты, обработчики) — только устранение предупреждения.
+- Не добавлять новые внешние зависимости.


### PR DESCRIPTION
## Summary
- Adds `docs/issues/19.md` exporting issue #19's description, acceptance criteria and negative constraints per the Issue phase of the CLAUDE.md workflow.
- Related to #19.

## Test plan
- [x] N/A — documentation only, no code changed.