### PR TITLE
fix(telegram-bot): suppress false-positive per_message PTBUserWarning

### DIFF
--- a/services/telegram-bot/telegram_bot.py
+++ b/services/telegram-bot/telegram_bot.py
@@ -2,11 +2,21 @@ import asyncio
 import logging
 import os
 import sys
+from warnings import filterwarnings
 from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup, InputMediaPhoto
 from telegram.ext import (
     ApplicationBuilder, CommandHandler, MessageHandler, CallbackQueryHandler,
     ConversationHandler, filters, ContextTypes
 )
+from telegram.warnings import PTBUserWarning
+
+# ConversationHandler ниже смешивает состояния только с CallbackQueryHandler
+# и состояния только с MessageHandler, поэтому per_message=True невозможен
+# (per_message=True отбрасывает все обновления без callback_query — сломает
+# текстовые состояния). Опросник — линейный один-пользователь-один-диалог,
+# трекинг CallbackQueryHandler по (chat_id, user_id) вместо per-message
+# корректен по дизайну, так что предупреждение — ложное срабатывание (issue #19).
+filterwarnings(action="ignore", message=r".*CallbackQueryHandler", category=PTBUserWarning)
 
 logging.basicConfig(
     format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',


### PR DESCRIPTION
## Summary
- `ConversationHandler` (services/telegram-bot/telegram_bot.py) mixes states with only `CallbackQueryHandler` and states with only `MessageHandler`. `per_message=True` isn't viable here — it drops any update without a `callback_query`, which would break every text-input state.
- The questionnaire is a linear one-user-one-dialog flow, so per-chat/per-user `CallbackQueryHandler` tracking (the `per_message=False` default) is correct by design — the `PTBUserWarning` is a false positive.
- Suppress precisely that warning via `warnings.filterwarnings` (scoped to the `CallbackQueryHandler` message text, not a blanket `PTBUserWarning` mute), per the python-telegram-bot FAQ's documented approach.

Closes #19.

## Test plan
- [x] Verified locally in a venv with `python-telegram-bot[job-queue]==21.9`: constructing the mixed-handler `ConversationHandler` emits the warning without the filter, and emits nothing with the filter applied first.
- [ ] After deploy, confirm `docker compose logs telegram-bot` no longer shows the `PTBUserWarning` on startup.
- [ ] Manually run through the questionnaire (inline-button states and free-text states) to confirm no behavior change.