### PR TITLE
feat(observability): compose.observability.yaml — Loki + Alloy + Grafana

### DIFF
--- a/compose.observability.yaml
+++ b/compose.observability.yaml
@@ -1,0 +1,73 @@
+services:
+  # Официальный образ Loki работает под непривилегированным uid 10001 и не содержит
+  # шелла (distroless), а свежий named volume монтируется с правами root — чиним
+  # владельца отдельным busybox-контейнером перед стартом.
+  loki-init:
+    image: busybox:1.36.1
+    user: root
+    entrypoint:
+      - sh
+      - -c
+      - mkdir -p /loki/chunks /loki/rules && chown -R 10001:10001 /loki
+    volumes:
+      - loki_data:/loki
+    networks:
+      - tourismania_network
+
+  loki:
+    image: grafana/loki:3.6.0
+    command: -config.file=/etc/loki/loki-config.yaml
+    depends_on:
+      loki-init:
+        condition: service_completed_successfully
+    volumes:
+      - ./services/observability/loki/loki-config.yaml:/etc/loki/loki-config.yaml:ro
+      - loki_data:/loki
+    expose:
+      - "3100"
+    networks:
+      - tourismania_network
+
+  alloy:
+    image: grafana/alloy:v1.17.1
+    command:
+      - run
+      - --server.http.listen-addr=0.0.0.0:12345
+      - --storage.path=/var/lib/alloy/data
+      - /etc/alloy/config.alloy
+    volumes:
+      - ./services/observability/alloy/config.alloy:/etc/alloy/config.alloy:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - alloy_data:/var/lib/alloy/data
+    expose:
+      - "12345"
+    depends_on:
+      - loki
+    networks:
+      - tourismania_network
+
+  grafana:
+    image: grafana/grafana:12.4.0
+    environment:
+      GF_SECURITY_ADMIN_USER: ${GRAFANA_ADMIN_USER:-admin}
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD}
+      GF_USERS_ALLOW_SIGN_UP: "false"
+    volumes:
+      - ./services/observability/grafana/provisioning:/etc/grafana/provisioning:ro
+      - grafana_data:/var/lib/grafana
+    ports:
+      - "3000:3000"
+    depends_on:
+      - loki
+    networks:
+      - tourismania_network
+
+volumes:
+  loki_data:
+  alloy_data:
+  grafana_data:
+
+networks:
+  tourismania_network:
+    external: true
+    name: ${COMPOSE_PROJECT_NAME}_tourismania_network

--- a/docs/issues/24.md
+++ b/docs/issues/24.md
@@ -1,0 +1,57 @@
+# Issue #24 — Централизованное хранение и просмотр логов вне docker logs (Grafana Loki + Alloy + Grafana)
+
+GitHub Issue: https://github.com/tourismania/infra-docker/issues/24
+
+## Проблема
+
+Логи всех сервисов стека (`nginx`, `web`, `api`, `postgres`, `kafka`, `kafka-ui`, `telegram-bot`, `xray`) были доступны только через `docker compose logs`/`docker logs` — без истории после ротации/пересоздания контейнера, без полнотекстового поиска и без единого места для просмотра логов сразу нескольких сервисов.
+
+## Исследование решений
+
+Сравнивались варианты хранения логов отдельно от Docker:
+
+| Решение | Для чего | Вердикт для нашего VPS |
+|---|---|---|
+| Grafana Loki + Alloy + Grafana | Агрегация логов, индексация только labels (дёшево по ресурсам), единый Grafana UI | ✅ Выбрано |
+| VictoriaLogs | Ещё более лёгкая альтернатива Loki | Резервный вариант, экосистема/дашборды скромнее |
+| ELK/EFK (Elasticsearch+Logstash/Fluentd+Kibana) | Полнотекстовый поиск, индустриальный стандарт | ❌ Слишком тяжело для небольшого VPS |
+| Graylog | UI+алерты из коробки, но тоже на Elasticsearch/OpenSearch+MongoDB | ❌ Та же проблема с ресурсами |
+| SigNoz / OpenObserve | Логи+метрики+трейсы в одном стеке (ClickHouse) | ⚠️ Тяжелее, чем нужно на старте, но похожая философия "одна платформа под весь observability" |
+| Dozzle | Просмотр `docker logs` в реальном времени без хранения истории | ❌ Не решает задачу — нет отдельного хранилища и поиска по истории |
+
+**Решение:** Grafana Loki (хранилище) + Grafana Alloy (сборщик логов из Docker) + Grafana (UI). Индексируются только метаданные (labels), а не полный текст — за счёт этого стек лёгкий и подходит для небольшого VPS. Ключевой плюс — тот же Grafana UI и та же платформа используются, если позже понадобится добавить метрики (Prometheus) и трейсинг (Tempo), без смены инструментов.
+
+## Acceptance Criteria
+
+- [x] Добавлены сервисы `loki`, `alloy`, `grafana` в отдельный `compose.observability.yaml` (не трогая основной `compose.yaml`), подключённые к `tourismania_network`.
+- [x] Loki настроен на filesystem storage (schema `tsdb`) с отдельным named volume для персистентности логов между перезапусками.
+- [x] Alloy собирает логи всех Docker-контейнеров (`discovery.docker` + `loki.source.docker`), парсит стандартный Docker JSON log-формат (`stage.docker`) и пересылает в Loki (`loki.write`); Docker socket монтируется read-only.
+- [x] Grafana поднимается с уже provisioned Loki datasource — без ручной настройки после первого старта.
+- [x] Учётные данные Grafana (admin user/password) передаются только через переменные окружения `.env` (`GRAFANA_ADMIN_USER`/`GRAFANA_ADMIN_PASSWORD`).
+- [x] Наружу (`ports`) торчит только Grafana; Loki и Alloy доступны только внутри `tourismania_network`.
+- [ ] Добавлен nginx-роутинг для Grafana (`grafana.tourismania.ru` в production, `grafana.localhost` в local) по аналогии с `kafka-ui`.
+- [ ] `Makefile`/workflow обновлены или задокументирован способ подключения `compose.observability.yaml` вместе с основным стеком.
+- [ ] Обновлена документация: `CLAUDE.md` (таблицы Services, Nginx Routing, Repository Structure).
+
+## Negative Constraints
+
+- Не трогать существующие сервисы и `networks`/`volumes` в `compose.yaml` — только новый отдельный файл.
+- Не использовать тяжёлые стеки (ELK/Graylog) — явное ограничение по ресурсам небольшого VPS.
+- Не хранить пароли/секреты Grafana в самом compose-файле — только через `.env`.
+- Loki/Alloy не должны публиковаться наружу через `ports` — только внутри `tourismania_network`.
+- Не проектировать заранее под метрики/трейсинг (Prometheus/Tempo) в рамках этой задачи — только логи.
+
+## Реализация (текущий этап)
+
+- `compose.observability.yaml` — новый отдельный compose-файл (не подключён по умолчанию, запускается через `-f`), сервисы:
+  - `loki-init` — одноразовый `busybox`-контейнер, чинит владельца named volume `loki_data` (образ Loki — distroless, работает под непривилегированным uid `10001`, а свежий named volume монтируется с правами root).
+  - `loki` (`grafana/loki:3.6.0`) — filesystem storage, схема `tsdb`, конфиг `services/observability/loki/loki-config.yaml`.
+  - `alloy` (`grafana/alloy:v1.17.1`) — читает Docker socket (read-only), собирает логи всех контейнеров через `discovery.docker`/`loki.source.docker`, парсит Docker JSON-формат (`stage.docker`) и пишет в Loki.
+  - `grafana` (`grafana/grafana:12.4.0`) — с provisioned datasource `services/observability/grafana/provisioning/datasources/loki.yaml`, порт `3000` наружу (временно, до появления nginx-роутинга).
+- `services/observability/loki/loki-config.yaml`, `services/observability/alloy/config.alloy`, `services/observability/grafana/provisioning/datasources/loki.yaml` — конфиги сервисов.
+- Версии образов подобраны как последние стабильные релизы на момент разработки (Loki 3.6.0, Alloy v1.17.1, Grafana 12.4.0), закреплены явно (без `latest`) по конвенции репозитория.
+- Стек проверен end-to-end локально: сервисы поднимаются вместе с существующей `tourismania_network`, Alloy реально забирает логи всех контейнеров (включая `telegram-bot`), Loki отдаёт их по запросу, datasource в Grafana подключается и проходит health-check.
+
+**Требуется перед запуском:** задать в `.env` переменную `GRAFANA_ADMIN_PASSWORD` (обязательна, без дефолта) и опционально `GRAFANA_ADMIN_USER` (по умолчанию `admin`).
+
+**Следующие этапы:** nginx-роутинг для Grafana, обновление `Makefile`/`.env.example` и `CLAUDE.md`.

--- a/services/observability/alloy/config.alloy
+++ b/services/observability/alloy/config.alloy
@@ -1,0 +1,31 @@
+discovery.docker "containers" {
+  host = "unix:///var/run/docker.sock"
+}
+
+discovery.relabel "containers" {
+  targets = discovery.docker.containers.targets
+
+  rule {
+    source_labels = ["__meta_docker_container_name"]
+    regex         = "/(.*)"
+    target_label  = "container"
+  }
+}
+
+loki.source.docker "containers" {
+  host       = "unix:///var/run/docker.sock"
+  targets    = discovery.relabel.containers.output
+  forward_to = [loki.process.containers.receiver]
+}
+
+loki.process "containers" {
+  stage.docker {}
+
+  forward_to = [loki.write.loki.receiver]
+}
+
+loki.write "loki" {
+  endpoint {
+    url = "http://loki:3100/loki/api/v1/push"
+  }
+}

--- a/services/observability/grafana/provisioning/datasources/loki.yaml
+++ b/services/observability/grafana/provisioning/datasources/loki.yaml
@@ -1,0 +1,10 @@
+apiVersion: 1
+
+datasources:
+  - name: Loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    isDefault: true
+    jsonData:
+      maxLines: 1000

--- a/services/observability/loki/loki-config.yaml
+++ b/services/observability/loki/loki-config.yaml
@@ -1,0 +1,26 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+
+common:
+  instance_addr: 127.0.0.1
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: 2024-01-01
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h


### PR DESCRIPTION
## Summary
- Первый этап issue #24: отдельный `compose.observability.yaml` (не подключён к основному стеку по умолчанию, запускается через `-f`) с сервисами `loki`, `alloy`, `grafana` для централизованного хранения и просмотра логов всех контейнеров вне `docker logs`.
- `loki-init` (одноразовый busybox) чинит владельца named volume `loki_data`, т.к. официальный образ Loki — distroless и работает под непривилегированным uid `10001`.
- Grafana поднимается с уже provisioned Loki datasource — без ручной настройки после первого старта.
- Наружу торчит только Grafana (`3000`, временно, до появления nginx-роутинга); Loki и Alloy — только внутри `tourismania_network`.

Следующие этапы (см. `docs/issues/24.md`): nginx-роутинг для Grafana, `.env.example`/`Makefile`, обновление `CLAUDE.md`.

## Test plan
- [x] `docker compose -f compose.observability.yaml config` — валиден.
- [x] Стек поднят локально вместе с реальным основным стеком (`tourismania_network`): все три контейнера стартуют без ошибок.
- [x] Alloy собирает и корректно парсит (`stage.docker`) логи всех контейнеров, включая `telegram-bot`, `api`, `nginx`.
- [x] Loki отдаёт собранные логи по запросу (`/loki/api/v1/query_range`).
- [x] Grafana datasource "Loki" проходит health-check (`Data source successfully connected`).
- [ ] Перед деплоем на сервер: задать в `.env` обязательную `GRAFANA_ADMIN_PASSWORD` (без дефолта) и опционально `GRAFANA_ADMIN_USER`.

**Примечание:** `.gitignore` содержит широкий паттерн `compose.*.yaml`, который случайно матчит и этот новый файл — пришлось закоммитить через `git add -f`. Возможно, стоит сузить паттерн (например, до `compose.local.yaml`), если `compose.*.yaml`-файлы для сервисов должны версионироваться.

🤖 Generated with [Claude Code](https://claude.com/claude-code)